### PR TITLE
Fix COMPOSER_INSTALL_OPTIONS ignored

### DIFF
--- a/extensions/composer/extension.py
+++ b/extensions/composer/extension.py
@@ -370,6 +370,7 @@ class ComposerCommandRunner(object):
         env['COMPOSER_VENDOR_DIR'] = self._ctx['COMPOSER_VENDOR_DIR']
         env['COMPOSER_BIN_DIR'] = self._ctx['COMPOSER_BIN_DIR']
         env['COMPOSER_CACHE_DIR'] = self._ctx['COMPOSER_CACHE_DIR']
+        env['COMPOSER_INSTALL_OPTIONS'] = self._ctx['COMPOSER_INSTALL_OPTIONS']
 
         # prevent key system variables from being overridden
         env['LD_LIBRARY_PATH'] = self._strategy.ld_library_path()


### PR DESCRIPTION

Thanks for contributing to the buildpack. To speed up the process of reviewing your pull request please provide us with:

* A short explanation of the proposed change:
All composer options set on options.json in COMPOSER_INSTALL_OPTIONS is ignored.
It seems not handled in code.
Add it !
(Maybe some other composer option not handled...)

* An explanation of the use cases your change solves
COMPOSER_INSTALL_OPTIONS take effect

* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `develop` branch

* [ ] I have added an integration test
